### PR TITLE
Counts when blocks were mined over 2 hours apart consecutively

### DIFF
--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -177,6 +177,7 @@ func (b *BlockChain) ProcessBlock(block *btcutil.Block, flags BehaviorFlags) (bo
 	// used to eat memory, and ensuring expected (versus claimed) proof of
 	// work requirements since the previous checkpoint are met.
 	blockHeader := &block.MsgBlock().Header
+
 	checkpointNode, err := b.findPreviousCheckpoint()
 	if err != nil {
 		return false, false, err
@@ -237,6 +238,9 @@ func (b *BlockChain) ProcessBlock(block *btcutil.Block, flags BehaviorFlags) (bo
 	if err != nil {
 		return false, false, err
 	}
+
+	fmt.Printf("XXXXX BlockHash: %v PrevBlock: %v Timestamp: %v\n",
+		blockHash, blockHeader.PrevBlock, blockHeader.Timestamp)
 
 	log.Debugf("Accepted block %v", blockHash)
 

--- a/timestamps.rb
+++ b/timestamps.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/ruby
+
+require 'date'
+
+HOUR = 60*60
+
+previous = -1
+previousTime = nil
+
+blocks = []
+blockMap = {}
+
+ARGF.each_line do |line|
+  blockHash, prevBlock, timestamp = line.match(/^XXXXX BlockHash: ([^ ]*) PrevBlock: ([^ ]*) Timestamp: (.*)/).captures
+
+  datetime = DateTime.parse(timestamp)
+  current = datetime.strftime("%s").to_i
+
+  if previous == -1 
+    previous = current
+    previousTime = datetime
+  else
+    blockMap[blockHash] = datetime
+  end
+
+  blocks << [blockHash, prevBlock]
+
+  if (current - previous) >= (2 * HOUR) 
+    #puts "FOUND 2 HOUR DIFFERENCE of #{current - previous} previousTime #{previousTime} currentTime #{datetime}"
+  end
+
+  previous = datetime.strftime("%s").to_i
+  previousTime = datetime
+end
+
+# this is to double check that the prev block and the current block are in succession (that the input log isn't faulty)
+# turns out the input isn't faulty however using this just in case...
+blocks.each do |block|
+  blockHash, prevBlock = block
+
+  if blockMap.has_key?(blockHash) && blockMap.has_key?(prevBlock)
+    current = blockMap[blockHash].strftime("%s").to_i
+    previous = blockMap[prevBlock].strftime("%s").to_i
+
+    if (current - previous) >= (2 * HOUR) 
+      puts "FOUND 2 HOUR DIFFERENCE of #{current - previous} previousTime #{blockMap[prevBlock]} currentTime #{blockMap[blockHash]}"
+    end
+  end
+end
+


### PR DESCRIPTION
Shows the ruby program that finds blocks that were consecutively mined 2 or more hours apart and the one modification to the btcd client to print out block headers as they are synced from peers.